### PR TITLE
Update the link to the repo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "main": "./lib/mixed-indent-warning",
   "version": "0.3.0",
   "description": "An Atom editor plugin to mark lines that have differing indentation.",
-  "repository": "https://github.com/sirbrillig/mixed-indent-warning",
+  "repository": "https://github.com/sirbrillig/mixed-indent-warning-old",
   "license": "MIT",
   "engines": {
     "atom": ">=0.174.0 <2.0.0"


### PR DESCRIPTION
I was unaware that two versions of the package exist: https://github.com/sirbrillig/linter-mixed-indent and https://github.com/sirbrillig/mixed-indent-warning-old. Seems like `linter-mixed-indent` was renamed from `mixed-indent-warning` and now GitHub aliases them. That's why many people (me included) go spamming the new repository with deprecation issues that are no longer relevant to the package.

This will update the repo link to hopefully prevent people from mistaking repos in the future. That involves creating another release of this package on atom.io (which should also bring the deprecation notice from this README to the package page).